### PR TITLE
Updated to highlight a few more language constructs in GitHub style

### DIFF
--- a/GitHub.tmTheme
+++ b/GitHub.tmTheme
@@ -47,6 +47,58 @@
 				<string>#999988</string>
 			</dict>
 		</dict>
+        <dict>
+            <key>name</key>
+            <string>Docblock</string>
+            <key>scope</key>
+            <string>comment.block</string>
+            <key>settings</key>
+            <dict>
+                <key>fontStyle</key>
+                <string></string>
+                <key>foreground</key>
+                <string>#DD1144</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>name</key>
+            <string>Docblock tag</string>
+            <key>scope</key>
+            <string>keyword.other.phpdoc</string>
+            <key>settings</key>
+            <dict>
+                <key>fontStyle</key>
+                <string></string>
+                <key>foreground</key>
+                <string>#DD1144</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>name</key>
+            <string>Core function</string>
+            <key>scope</key>
+            <string>support.function</string>
+            <key>settings</key>
+            <dict>
+                <key>fontStyle</key>
+                <string></string>
+                <key>foreground</key>
+                <string>#0086B3</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>name</key>
+            <string>Core function construct</string>
+            <key>scope</key>
+            <string>support.function.construct</string>
+            <key>settings</key>
+            <dict>
+                <key>fontStyle</key>
+                <string>bold</string>
+                <key>foreground</key>
+                <string>#000000</string>
+            </dict>
+        </dict>
 		<dict>
 			<key>name</key>
 			<string>Keyword</string>
@@ -262,6 +314,19 @@
 				<string>#000000</string>
 			</dict>
 		</dict>
+        <dict>
+            <key>name</key>
+            <string>Method call</string>
+            <key>scope</key>
+            <string>meta.function-call</string>
+            <key>settings</key>
+            <dict>
+                <key>fontStyle</key>
+                <string></string>
+                <key>foreground</key>
+                <string>#108888</string>
+            </dict>
+        </dict>
 		<dict>
 			<key>name</key>
 			<string>hash brackets</string>

--- a/GitHub.tmTheme
+++ b/GitHub.tmTheme
@@ -203,7 +203,7 @@
 			<key>name</key>
 			<string>Built-in constant</string>
 			<key>scope</key>
-			<string>constant.language</string>
+			<string>constant.language, support.function.construct</string>
 			<key>settings</key>
 			<dict>
 				<key>fontStyle</key>

--- a/GitHub.tmTheme
+++ b/GitHub.tmTheme
@@ -86,19 +86,6 @@
                 <string>#0086B3</string>
             </dict>
         </dict>
-        <dict>
-            <key>name</key>
-            <string>Core function construct</string>
-            <key>scope</key>
-            <string>support.function.construct</string>
-            <key>settings</key>
-            <dict>
-                <key>fontStyle</key>
-                <string>bold</string>
-                <key>foreground</key>
-                <string>#000000</string>
-            </dict>
-        </dict>
 		<dict>
 			<key>name</key>
 			<string>Keyword</string>
@@ -140,7 +127,7 @@
 			<key>name</key>
 			<string>Function (definition)</string>
 			<key>scope</key>
-			<string>entity.name.function, keyword.other.name-of-parameter.objc</string>
+			<string>entity.name.function, keyword.other.name-of-parameter.objc, support.type.exception.python</string>
 			<key>settings</key>
 			<dict>
 				<key>fontStyle</key>
@@ -325,6 +312,19 @@
                 <string></string>
                 <key>foreground</key>
                 <string>#108888</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>name</key>
+            <string>Method call</string>
+            <key>scope</key>
+            <string>meta.function-call.python</string>
+            <key>settings</key>
+            <dict>
+                <key>fontStyle</key>
+                <string></string>
+                <key>foreground</key>
+                <string>#000000</string>
             </dict>
         </dict>
 		<dict>


### PR DESCRIPTION
I updated the theme definition to cover a few more language constructs that GitHub was picking up differently from the theme. I tested mostly in PHP and Python, using Sublime Text 2. Most notably in PHP this pull request fixes constructs like 

``` php
array()
isset()
array_merge()
```

In addition to all OOP style method invocation, such as 

``` php
$this->getContent();
```

where the method name was not being highlighted correctly. In Python, errors like

``` python
ImportError
```

should be handled correctly now as well. 

Let me know if there is anything I missed and I would be happy to send along another PR.
